### PR TITLE
Support multiple plot values in .properties file format

### DIFF
--- a/src/main/java/hudson/plugins/plot/PropertiesSeries.java
+++ b/src/main/java/hudson/plugins/plot/PropertiesSeries.java
@@ -9,10 +9,13 @@ package hudson.plugins.plot;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.util.List;
 import java.util.Properties;
 
 import hudson.FilePath;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import com.google.common.collect.Lists;
 
 /**
  * @author Allen Reese
@@ -45,19 +48,45 @@ public class PropertiesSeries extends Series {
         }
         
         try {
+            List<PlotPoint> plotPoints = Lists.newArrayList();
+
             in = seriesFiles[0].read();
             logger.println("Saving plot series data from: " + seriesFiles[0]);
             Properties properties = new Properties();
             properties.load(in);
-            String yvalue = properties.getProperty("YVALUE");
-            String url = properties.getProperty("URL","");
-            if (yvalue == null || url == null)
+
             {
-            	logger.println("Not creating point with null values: y=" + yvalue + " label=" + getLabel() + " url="+url);
-            	return null;
+                String yvalue = properties.getProperty("YVALUE");
+                String url = properties.getProperty("URL", "");
+                if (yvalue != null && url != null) {
+                    plotPoints.add(new PlotPoint(yvalue, url, getLabel()));
+                }
             }
-            
-    		return new PlotPoint[]{new PlotPoint(yvalue,url,getLabel())};
+
+            // Support multiple values using YVALUE.<X>, URL.<X>, LABEL.<X>
+            // syntax
+            // Label defaults to <X> if LABEL.<X> is not found
+            for (String key : properties.stringPropertyNames()) {
+                final String PREFIX = "YVALUE.";
+
+                if (key.startsWith(PREFIX)) {
+                    String suffix = key.substring(PREFIX.length());
+
+                    String yvalue = properties.getProperty("YVALUE." + suffix);
+                    String url = properties.getProperty("URL." + suffix, "");
+                    String label = properties.getProperty("LABEL." + suffix, suffix);
+
+                    if (yvalue != null && url != null && label != null) {
+                        plotPoints.add(new PlotPoint(yvalue, url, label));
+                    }
+                }
+            }
+
+            if (plotPoints.size() == 0) {
+                logger.println("No point values found");
+                return null;
+            }
+            return (PlotPoint[]) plotPoints.toArray(new PlotPoint[plotPoints.size()]);
         } catch (Exception e) {
             logger.println("Exception reading plot series data from: " + seriesFiles[0]);
             return null;


### PR DESCRIPTION
"The property file is scanned for keys like YVALUE.[X].  If one is found, LABEL.[X] and URL.[X] are also checked.  The label defaults to [X] if not specified."

Should I also create a bug at issues.jenkins-ci.org to track this?
