### PR TITLE
Fixing an incorrect pattern match target (in name/label replacement in the URL)

### DIFF
--- a/src/main/java/hudson/plugins/plot/CSVSeries.java
+++ b/src/main/java/hudson/plugins/plot/CSVSeries.java
@@ -350,7 +350,7 @@ public class CSVSeries extends Series {
 		/*
 		 * Check the name first, and do replacement upon it.
 		 */
-		Matcher nameMatcher = PAT_NAME.matcher(label);
+		Matcher nameMatcher = PAT_NAME.matcher(url);
 		if (nameMatcher.find())
 		{
 			url = nameMatcher.replaceAll(label);
@@ -359,7 +359,7 @@ public class CSVSeries extends Series {
 		/*
 		 * Check the index, and do replacement on it.
 		 */
-		Matcher indexMatcher = PAT_INDEX.matcher(label);
+		Matcher indexMatcher = PAT_INDEX.matcher(url);
 		if (indexMatcher.find())
 		{
 			url = indexMatcher.replaceAll(label);


### PR DESCRIPTION
The code as before would look for "%name%" in the label (which is the
CSV column header) and replace it with the label again, and then make
that the URL.  This makes no sense.

This change makes the code work with what I believe the intention of the
pattern matching was.
