### PR TITLE
Plot: Ensure uniqueness of the temporary file by creating its name la…

### DIFF
--- a/src/main/java/hudson/plugins/plot/Plot.java
+++ b/src/main/java/hudson/plugins/plot/Plot.java
@@ -201,11 +201,6 @@ public class Plot implements Comparable<Plot> {
         this.yaxis = yaxis;
         this.group = group;
         this.numBuilds = numBuilds;
-        if (StringUtils.isBlank(csvFileName)) {
-            // TODO: check project dir to ensure uniqueness instead of just
-            // random
-            csvFileName = Math.abs(new Random().nextInt()) + ".csv";
-        }
         this.csvFileName = csvFileName;
         this.style = style;
         this.useDescr = useDescr;
@@ -251,7 +246,7 @@ public class Plot implements Comparable<Plot> {
                 + "),NUMBUILDS(" + numBuilds + "),RIGHTBUILDNUM("
                 + getRightBuildNum() + "),HASLEGEND(" + hasLegend()
                 + "),ISLOGARITHMIC(" + isLogarithmic() + "),FILENAME("
-                + csvFileName + ")";
+                + getCsvFileName() + ")";
     }
 
     public String getYaxis() {
@@ -267,6 +262,13 @@ public class Plot implements Comparable<Plot> {
     }
 
     public String getCsvFileName() {
+        if (StringUtils.isBlank(csvFileName) && project != null) {
+            try {
+                csvFileName = File.createTempFile("plot-", ".csv", project.getRootDir()).getName();
+            } catch (IOException e) {
+                LOGGER.log(Level.SEVERE, "Unable to create temporary CSV file.", e);
+            }
+        }
         return csvFileName;
     }
 


### PR DESCRIPTION
…zily

We cannot ensure uniqueness of the temporary file in the constructor
because we do not know the project root directory at that time. So do not
create its name until getCsvFileName() has been called fo rthe first time,
by which time setProject() should have been called.