### PR TITLE
[JENKINS-24234] Use the TokenMacro plugin to allow filename to be specified using a variable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
       <artifactId>opencsv</artifactId>
       <version>1.7</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>token-macro</artifactId>
+      <version>1.10</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/hudson/plugins/plot/CSVSeries.java
+++ b/src/main/java/hudson/plugins/plot/CSVSeries.java
@@ -132,7 +132,7 @@ public class CSVSeries extends Series {
 
             FilePath[] seriesFiles = null;
             try {
-                seriesFiles = workspaceRootDir.list(getFile());
+                seriesFiles = workspaceRootDir.list(getRealFile());
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE,
                         "Exception trying to retrieve series files", e);
@@ -141,14 +141,14 @@ public class CSVSeries extends Series {
 
             if (ArrayUtils.isEmpty(seriesFiles)) {
                 LOGGER.info("No plot data file found: "
-                        + workspaceRootDir.getName() + " " + getFile());
+                        + workspaceRootDir.getName() + " " + getRealFile());
                 return null;
             }
 
             try {
                 if (LOGGER.isLoggable(defaultLogLevel))
                     LOGGER.log(defaultLogLevel,
-                            "Loading plot series data from: " + getFile());
+                            "Loading plot series data from: " + getRealFile());
 
                 in = seriesFiles[0].read();
             } catch (Exception e) {
@@ -160,7 +160,7 @@ public class CSVSeries extends Series {
 
             if (LOGGER.isLoggable(defaultLogLevel))
                 LOGGER.log(defaultLogLevel, "Loaded CSV Plot file: "
-                        + getFile());
+                        + getRealFile());
 
             // load existing plot file
             inputReader = new InputStreamReader(in);

--- a/src/main/java/hudson/plugins/plot/MatrixPlotPublisher.java
+++ b/src/main/java/hudson/plugins/plot/MatrixPlotPublisher.java
@@ -182,6 +182,7 @@ public class MatrixPlotPublisher extends AbstractPlotPublisher {
         // add the build to each plot
         for (Plot plot : plotsOfConfigurations.get(((MatrixRun) build)
                 .getProject())) {
+            plot.expandTokens(build, listener);
             plot.addBuild(build, listener.getLogger());
         }
         // misconfigured plots will not fail a build so always return true

--- a/src/main/java/hudson/plugins/plot/PlotPublisher.java
+++ b/src/main/java/hudson/plugins/plot/PlotPublisher.java
@@ -156,6 +156,7 @@ public class PlotPublisher extends AbstractPlotPublisher {
         listener.getLogger().println("Recording plot data");
         // add the build to each plot
         for (Plot plot : getPlots()) {
+            plot.expandTokens(build, listener);
             plot.addBuild(build, listener.getLogger());
         }
         // misconfigured plots will not fail a build so always return true

--- a/src/main/java/hudson/plugins/plot/PropertiesSeries.java
+++ b/src/main/java/hudson/plugins/plot/PropertiesSeries.java
@@ -42,7 +42,7 @@ public class PropertiesSeries extends Series {
         FilePath[] seriesFiles = null;
 
         try {
-            seriesFiles = workspaceRootDir.list(getFile());
+            seriesFiles = workspaceRootDir.list(getRealFile());
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE,
                     "Exception trying to retrieve series files", e);
@@ -50,7 +50,7 @@ public class PropertiesSeries extends Series {
         }
 
         if (ArrayUtils.isEmpty(seriesFiles)) {
-            logger.println("No plot data file found: " + getFile());
+            logger.println("No plot data file found: " + getRealFile());
             return null;
         }
 

--- a/src/main/java/hudson/plugins/plot/Series.java
+++ b/src/main/java/hudson/plugins/plot/Series.java
@@ -30,6 +30,12 @@ public abstract class Series {
     protected String file;
 
     /**
+     * The value of 'file' above after expanding embedded tokens in it.
+     * Token expansion happens just before the series data is read.
+     */
+    protected String realfile;
+
+    /**
      * Data series legend label. Optional.
      */
     protected String label;
@@ -64,6 +70,14 @@ public abstract class Series {
 
     public String getFileType() {
         return fileType;
+    }
+
+    protected void setRealFile(String s) {
+        realfile = s;
+    }
+
+    protected String getRealFile() {
+        return realfile;
     }
 
     /**

--- a/src/main/java/hudson/plugins/plot/XMLSeries.java
+++ b/src/main/java/hudson/plugins/plot/XMLSeries.java
@@ -212,7 +212,7 @@ public class XMLSeries extends Series {
             FilePath[] seriesFiles = null;
 
             try {
-                seriesFiles = workspaceRootDir.list(getFile());
+                seriesFiles = workspaceRootDir.list(getRealFile());
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE,
                         "Exception trying to retrieve series files", e);
@@ -220,14 +220,14 @@ public class XMLSeries extends Series {
             }
 
             if (ArrayUtils.isEmpty(seriesFiles)) {
-                LOGGER.info("No plot data file found: " + getFile());
+                LOGGER.info("No plot data file found: " + getRealFile());
                 return null;
             }
 
             try {
                 if (LOGGER.isLoggable(defaultLogLevel))
                     LOGGER.log(defaultLogLevel,
-                            "Loading plot series data from: " + getFile());
+                            "Loading plot series data from: " + getRealFile());
 
                 in = seriesFiles[0].read();
                 // load existing plot file
@@ -245,7 +245,7 @@ public class XMLSeries extends Series {
 
             if (LOGGER.isLoggable(defaultLogLevel))
                 LOGGER.log(defaultLogLevel, "Loaded XML Plot file: "
-                        + getFile());
+                        + getRealFile());
 
             XPath xpath = XPathFactory.newInstance().newXPath();
             Object xmlObject = xpath.evaluate(xpathString, inputSource,


### PR DESCRIPTION
Use the TokenMacro plugin to allow a variable to bespecified as the series filename. The token is not substituted in-place (as this will get written back to the config). Instead a new variable is used to store the real filename and this variable is used to locate the series data relative to the workspace.