### PR TITLE
Don't create an extraneous column if CSV has a trailing comma

### DIFF
--- a/src/main/java/hudson/plugins/plot/CSVSeries.java
+++ b/src/main/java/hudson/plugins/plot/CSVSeries.java
@@ -186,6 +186,9 @@ public class CSVSeries extends Series {
 
                     yvalue = nextLine[index];
 
+                    if (yvalue.trim().length() == 0) // empty value, caused by e.g. trailing comma in CSV
+                    	continue;
+
                     if (index < headerLine.length)
                         label = headerLine[index];
 

--- a/src/test/java/hudson/plugins/plot/CSVSeriesTest.java
+++ b/src/test/java/hudson/plugins/plot/CSVSeriesTest.java
@@ -72,6 +72,31 @@ public class CSVSeriesTest extends SeriesTestCase {
         }
     }
 
+    public void testCSVSeriesWithTrailingSemicolonDoesntCreateExtraneousPoint() {
+        // first create a FilePath to load the test Properties file.
+        File workspaceDirFile = new File("target/test-classes/");
+        FilePath workspaceRootDir = new FilePath(workspaceDirFile);
+        String file = "test_trailing_semicolon.csv";
+        
+        LOGGER.info("workspace File path: "
+                + workspaceDirFile.getAbsolutePath());
+        LOGGER.info("workspace Dir path: " + workspaceRootDir.getName());
+
+        // Create a new CSV series.
+        CSVSeries series = new CSVSeries(file,
+                "http://localhost:8080/%name%/%index%/", "OFF", "", false);
+
+        LOGGER.info("Created series " + series.toString());
+        // test the basic subclass properties.
+        testSeries(series, file, "", "csv");
+
+        // load the series.
+        List<PlotPoint> points = series.loadSeries(workspaceRootDir, 0,
+                System.out);
+        LOGGER.info("Got " + points.size() + " plot points");
+        testPlotPoints(points, 8);
+    }
+    
     private int getNumColumns(FilePath workspaceRootDir, String file)
             throws IOException, InterruptedException {
         CSVReader csvreader = null;

--- a/src/test/resources/test_trailing_semicolon.csv
+++ b/src/test/resources/test_trailing_semicolon.csv
@@ -1,0 +1,3 @@
+Avg,Median,90,min,max,samples,errors,error %, 
+515.33,196,1117,2,16550,97560,360,0.37, 
+


### PR DESCRIPTION
Trailing commas at the end of the CSV containing the data series created an entry with "" as the yvalue in the temporary CSV file holding the plot data. As a consequence, generatePlot() will fail converting this to a number and log a message at level SEVERE, including an exception trace. On our CI system this caused roughly 600kB worth of logging per second, filling the disk within a day.

This commit deals with trailing commas by ignoring empty yvalues