### PR TITLE
[plot-plugin] add more docs on params and links, minor cleanup

### DIFF
--- a/src/main/java/hudson/plugins/plot/Plot.java
+++ b/src/main/java/hudson/plugins/plot/Plot.java
@@ -180,7 +180,7 @@ public class Plot implements Comparable<Plot> {
     /** Whether or not to use build descriptions as X-axis labels. Optional. */
     public boolean useDescr;
 
-    /** keep records for builds that was deleted */
+    /** Keep records for builds that were deleted. */
     private boolean keepRecords;
 
     /** Whether or not to exclude zero as default Y-axis value. Optional. */
@@ -347,12 +347,11 @@ public class Plot implements Comparable<Plot> {
     }
 
     /**
-     * Sets the number of builds to plot from the "numbuilds" parameter in the
-     * given StaplerRequest. If the parameter doesn't exist or isn't an integer
-     * then a default is used.
+     * Sets the "hasLegend" parameter in the given StaplerRequest. If the
+     * parameter doesn't exist then a default is used.
      */
     private void setHasLegend(StaplerRequest req) {
-        String legend = req.getParameter("legend");
+        String legend = req.getParameter("haslegend");
         hasLegend = legend == null || "on".equalsIgnoreCase(legend)
                 || "true".equalsIgnoreCase(legend);
     }
@@ -751,7 +750,7 @@ public class Plot implements Comparable<Plot> {
     }
 
     /**
-     * Creates a Chart of the style indicated by getEffStyle() using the given
+     * Creates a Chart of the style indicated by getUrlStyle() using the given
      * dataset. Defaults to using createLineChart.
      */
     private JFreeChart createChart(PlotCategoryDataset dataset) {

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -5,5 +5,32 @@
  */
  -->
 <div>
-  This plugin provides generic plotting (or graphing) capability.
+  <p>This plugin provides generic plotting (or graphing) capability. Documentation on how to use this plugin with the Jenkins Job Builder is available <a href="http://docs.openstack.org/infra/jenkins-job-builder/publishers.html#publishers.plot">here</a>. There are various supported parameters at this time. For a full list of parameters the best place to view them is <a href="https://github.com/jenkinsci/plot-plugin/blob/master/src/main/java/hudson/plugins/plot/Plot.java">here</a>.</p>
+  <p>The currently supported parameters are:</p>
+  <p>
+    <ul>
+      <li>width (int, default: 750): The width of the plot in pixels.</li>
+      <li>height (int, default: 450): The height of the plot in pixels.</li>
+      <li>rightBuildNum (int, default: 2^38 - 1): The right-most build number on the plot.</li>
+      <li>hasLegend (boolean, default: true): Whether or not the plot has a legend.</li>
+      <li>urlNumBuilds (string, default: 2^38 - 1): Number of builds back to show on this plot from url.</li>
+      <li>urlTitle (string, default: ""): Title of plot from url.</li>
+      <li>urlStyle (string, default: ""): Style of plot from url.</li>
+      <li>urlUseDescr (boolean, default: false): Use description flag from url.</li>
+      <li>title (string, default: ""): Title of plot.</li>
+      <li>yaxis (string, default: ""): Y-axis label.</li>
+      <li>series (list): List of data series.</li>
+      <li>group (string): Group name that this plot belongs to.</li>
+      <li>numBuilds (string, default: ""): Number of builds back to show on this plot. Empty string means all builds. Must not be "0".</li>
+      <li>csvFileName (string, default: "$ROOT_DIR/plot-XXXX.csv"): The name of the CSV file that persists the plots data. The CSV file is stored in the projects root directory. This is different from the source csv file that can be used as a source for the plot.</li>
+      <li>csvLastModification (long, default: "last modified date"): The date of the last change to the CSV file.</li>
+      <li>style (string, default: "line"): Style of plot: line, line3d, stackedArea, stackedBar, etc.</li>
+      <li>useDescr (boolean, default: false): Whether or not to use build descriptions as X-axis labels.</li>
+      <li>keepRecords (boolean, default: false): Keep records for builds that were deleted.</li>
+      <li>exclZero (boolean, default: false): Whether or not to exclude zero as default Y-axis value.</li>
+      <li>logarithmic (boolean, default: false): Use a logarithmic Y-axis.</li>
+      <li>yaxisMinimum (string, default: ""): Minimum y-axis value.</li>
+      <li>yaxisMaximum (string, default: ""): Maximum y-axis value.</li>
+    </ul>
+  </p>
 </div>


### PR DESCRIPTION
- Adds better docs in `index.jelly` for the page here: https://wiki.jenkins-ci.org/display/JENKINS/Plot+Plugin.  Specifically, on the params supported.
- Cleans up a few comments which didn't seem correct.
- The param. `legend` should be `haslegend` based on the code.