### PR TITLE
Format numbers in the cvs tables, modified table style

### DIFF
--- a/src/main/java/hudson/plugins/plot/PlotReport.java
+++ b/src/main/java/hudson/plugins/plot/PlotReport.java
@@ -12,6 +12,7 @@ import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.text.NumberFormat;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -74,6 +75,11 @@ public class PlotReport {
     // called from PlotReport/index.jelly
     public List<Plot> getPlots() {
         return plots;
+    }
+
+    // called from PlotReport/index.jelly
+    public String formatNumber(String number) {
+        return NumberFormat.getIntegerInstance().format(Integer.parseInt(number));
     }
 
     // called from PlotReport/index.jelly

--- a/src/main/resources/hudson/plugins/plot/PlotReport/index.jelly
+++ b/src/main/resources/hudson/plugins/plot/PlotReport/index.jelly
@@ -16,15 +16,15 @@
         <j:if test="${it.getDisplayTableFlag(index)}">
           <div>
           <p>
-          <table border="1">
+          <table class="stripped" style="text-align: right; border: 1px solid lightgray;border-collapse: collapse;">
           <j:forEach var="tuple" items="${it.getTable(index)}" varStatus="loopStat3">
-            <tr>
+            <tr style="border: 1px solid lightgray;">
             <j:forEach var="col" items="${tuple}">
               <j:if test="${loopStat3.index==0}">
-                <th> ${col} </th>
+                <th style="border: 1px solid lightgray;"> ${col} </th>
               </j:if>
               <j:if test="${loopStat3.index>0}">
-                <td> ${col} </td>
+                <td style="border: 1px solid lightgray;"> ${it.formatNumber(col)} </td>
               </j:if>
             </j:forEach>
             </tr>


### PR DESCRIPTION
It improves the CSV data tables visible above the graphs for CVS data series.

The numbers are formatted (i.e. they have thousand separators) and the table style is a bit improved.