### PR TITLE
Fix CSVSeries c'tor

### DIFF
--- a/src/main/java/hudson/plugins/plot/CSVSeries.java
+++ b/src/main/java/hudson/plugins/plot/CSVSeries.java
@@ -79,14 +79,13 @@ public class CSVSeries extends Series {
 
         if (exclusionValues == null) {
             this.inclusionFlag = InclusionFlag.OFF;
-            return;
+        } else {
+            this.inclusionFlag = InclusionFlag.valueOf(inclusionFlag);
         }
-
-        this.inclusionFlag = InclusionFlag.valueOf(inclusionFlag);
         this.exclusionValues = exclusionValues;
-        this.displayTableFlag = displayTableFlag;
-
         loadExclusionSet();
+
+        this.displayTableFlag = displayTableFlag;
     }
 
     public String getInclusionFlag() {

--- a/src/main/java/hudson/plugins/plot/CSVSeries.java
+++ b/src/main/java/hudson/plugins/plot/CSVSeries.java
@@ -76,16 +76,15 @@ public class CSVSeries extends Series {
         super(file, "", "csv");
 
         this.url = url;
+        this.displayTableFlag = displayTableFlag;
 
         if (exclusionValues == null) {
             this.inclusionFlag = InclusionFlag.OFF;
         } else {
             this.inclusionFlag = InclusionFlag.valueOf(inclusionFlag);
+            this.exclusionValues = exclusionValues;
+            loadExclusionSet();
         }
-        this.exclusionValues = exclusionValues;
-        loadExclusionSet();
-
-        this.displayTableFlag = displayTableFlag;
     }
 
     public String getInclusionFlag() {

--- a/src/test/java/hudson/plugins/plot/CSVSeriesTest.java
+++ b/src/test/java/hudson/plugins/plot/CSVSeriesTest.java
@@ -24,6 +24,11 @@ public class CSVSeriesTest extends SeriesTestCase {
 
     private static final String[] FILES = {"test.csv"};
 
+    public void testCSVSeriesWithNullExclusionValuesSetsDisplayTableFlag() {
+        CSVSeries series = new CSVSeries(FILES[0], null, null, null, true);
+        assertTrue(series.getDisplayTableFlag());
+    }
+
     public void testCSVSeriesWithNoExclusions() {
         // first create a FilePath to load the test Properties file.
         File workspaceDirFile = new File("target/test-classes/");


### PR DESCRIPTION
Seen by accident when looking at the code in github:
- Fix: 'displayTableFlag' may not have been set (when 'exclusionValues' is null)
- Enh (coding style): replace 'return' with 'else' tree for 'if' statement

I assume for a small change like this there is no need for a JIRA issue.
Likewise I am hesitating to add a little unit test: e.g. calling c'tor with 'displayTableFlag=true' and 'exclusionValues=null' and checking that 'getDisplayTableFlag()' now returns true.