### PR TITLE
Fix ChartStyle enum value identification from input name

### DIFF
--- a/src/main/java/hudson/plugins/plot/Plot.java
+++ b/src/main/java/hudson/plugins/plot/Plot.java
@@ -293,9 +293,16 @@ public class Plot implements Comparable<Plot> {
     }
 
     private enum ChartStyle {
-        AREA("name"), BAR("bar"), BAR_3D("bar3d"), LINE_3D("line3d"),
-        LINE_SIMPLE("lineSimple"), STACKED_AREA("stackedarea"), STACKED_BAR("stackedbar"),
-        STACKED_BAR_3D("stackedbar3d"), WATERFALL("waterfall");
+        AREA("area"),
+        BAR("bar"),
+        BAR_3D("bar3d"),
+        LINE("line"),
+        LINE_3D("line3d"),
+        LINE_SIMPLE("lineSimple"),
+        STACKED_AREA("stackedarea"),
+        STACKED_BAR("stackedbar"),
+        STACKED_BAR_3D("stackedbar3d"),
+        WATERFALL("waterfall");
 
         private final String name;
 
@@ -303,8 +310,13 @@ public class Plot implements Comparable<Plot> {
             this.name = name;
         }
 
-        public String getName() {
-            return name;
+        static ChartStyle forName(String name) {
+            for (ChartStyle chartStyle : ChartStyle.values()) {
+                if (name.equals(chartStyle.name)) {
+                    return chartStyle;
+                }
+            }
+            return ChartStyle.LINE_SIMPLE;
         }
     }
 
@@ -840,7 +852,7 @@ public class Plot implements Comparable<Plot> {
      * dataset. Defaults to using createLineChart.
      */
     private JFreeChart createChart(PlotCategoryDataset dataset) {
-        switch (ChartStyle.valueOf(getUrlStyle())) {
+        switch (ChartStyle.forName(getUrlStyle())) {
             case AREA:
                 return ChartFactory.createAreaChart(getURLTitle(), null,
                         getYaxis(), dataset, PlotOrientation.VERTICAL, hasLegend(), true, false);
@@ -868,6 +880,7 @@ public class Plot implements Comparable<Plot> {
             case WATERFALL:
                 return ChartFactory.createWaterfallChart(getURLTitle(), null,
                         getYaxis(), dataset, PlotOrientation.VERTICAL, hasLegend(), true, false);
+            case LINE:
             default:
                 return ChartFactory.createLineChart(getURLTitle(), null,
                         getYaxis(), dataset, PlotOrientation.VERTICAL, hasLegend(), true, false);


### PR DESCRIPTION
Jira: none
_(There was no Jira ticket at the moment of code cleanup. I wouldn't a create it for this fix too.)_

### What has been done
1. Fixed ChartStyle enum value identification based on provided name ("line3d" -> `ChartStyle.LINE_3D`). Breaking change was introduced in https://github.com/jenkinsci/plot-plugin/commit/5a67ffe639004d0d317c54ced84c9ebcbf595b33#diff-1adf2f6887cfd5b240cc5d0a9d898b61R794
![image](https://user-images.githubusercontent.com/3036347/34161648-fa21e696-e4d9-11e7-9993-dac1426f51b3.png)
2. Introduced `ChartStyle.LINE`. Previously there was no "line" chart style object, but it was in UI dropdown.

### Screenshots

Before | After
:-: | :-:
| ![image](https://user-images.githubusercontent.com/3036347/34161639-ef4134f2-e4d9-11e7-9f49-4f0c81393797.png) | ![image](https://user-images.githubusercontent.com/3036347/34161273-d9ddd0f8-e4d8-11e7-8f28-acec4cbec022.png)

### How to test
1. Build plugin from https://github.com/jenkinsci/plot-plugin/commit/5a67ffe639004d0d317c54ced84c9ebcbf595b33 commit and verify that plots don't render (Exception in Jenkins points to broken line of code).
2. Build plugin from this PR and make sure plots render just fine.
