### PR TITLE
Disable Checkstyle for InjectedTest.java

### DIFF
--- a/checkstyle/checkstyle-suppressions.xml
+++ b/checkstyle/checkstyle-suppressions.xml
@@ -5,6 +5,8 @@
 <suppressions>
     <suppress checks=".*" files="Messages.java"/>
     <suppress checks=".*" files="test.properties"/>
+    <!-- no check for automatically generated InjectedTest -->
+    <suppress checks=".*" files="InjectedTest.java"/>
     <suppress checks="LineLength" files=".*Test\.java"/>
     <!-- test methods names can contain "_" character -->
     <suppress checks="MethodNameCheck" files=".*Test\.java"/>


### PR DESCRIPTION
Jira: none. 

Release command fails due to Checkstyle errors in autogenerated `InjectedTest.java` class
<img width="1261" alt="screen shot 2018-01-03 at 11 14 39 am" src="https://user-images.githubusercontent.com/3036347/34515427-b4828ce2-f07a-11e7-9256-04b6eec6ff04.png">

### What has been done
1. Disabled Checkstyle for InjectedTest.java. It's an autogenerated test class, no need to check it with Checkstyle

### How to test
1. Run release command `mvn release:prepare`
