### PR TITLE
Slightly improve code consistency of parsing plot point values

### DIFF
--- a/src/main/java/hudson/plugins/plot/Plot.java
+++ b/src/main/java/hudson/plugins/plot/Plot.java
@@ -756,7 +756,7 @@ public class Plot implements Comparable<Plot> {
                 value = Integer.parseInt(record[0]);
             } catch (NumberFormatException nfe) {
                 try {
-                    value = Double.valueOf(record[0]);
+                    value = Double.parseDouble(record[0]);
                 } catch (NumberFormatException nfe2) {
                     LOGGER.log(Level.SEVERE, "Exception converting to number", nfe2);
                     continue; // skip this record all together


### PR DESCRIPTION
No JIRA issue.
Behaviour does not change at all.

=> This PR is just making the code a little bit more consistent: cf. `Integer.parseInt` (three lines above: https://github.com/reinholdfuereder/plot-plugin/blob/05f42634f08f7f0e8d56aed2598c96e3886a9eea/src/main/java/hudson/plugins/plot/Plot.java#L756) and many other `<NumericType>.parse<NumericType>` calls in the plugin code.