### PR TITLE
[JENKINS-48887] PlotBuilder ignores useDescr, keepRecords, exclZero and logarithmic 

### DIFF
--- a/src/main/java/hudson/plugins/plot/Plot.java
+++ b/src/main/java/hudson/plugins/plot/Plot.java
@@ -810,7 +810,6 @@ public class Plot implements Comparable<Plot> {
         // selected
         if (isLogarithmic()) {
             LogarithmicAxis logAxis = new LogarithmicAxis(getYaxis());
-            logAxis.setExpTickLabelsFlag(true);
             categoryPlot.setRangeAxis(logAxis);
         }
 

--- a/src/main/java/hudson/plugins/plot/PlotBuilder.java
+++ b/src/main/java/hudson/plugins/plot/PlotBuilder.java
@@ -39,10 +39,10 @@ public class PlotBuilder extends Builder implements SimpleBuildStep {
     private final String numBuilds;
     private final String yaxis;
     private final String style;
-    private final Boolean useDescr;
-    private final Boolean exclZero;
-    private final Boolean logarithmic;
-    private final Boolean keepRecords;
+    private final boolean useDescr;
+    private final boolean exclZero;
+    private final boolean logarithmic;
+    private final boolean keepRecords;
     private final String yaxisMinimum;
     private final String yaxisMaximum;
     @SuppressWarnings("visibilitymodifier")
@@ -63,7 +63,7 @@ public class PlotBuilder extends Builder implements SimpleBuildStep {
     @SuppressWarnings("parameternumber")
     @DataBoundConstructor
     public PlotBuilder(String group, String title, String numBuilds, String yaxis, String style,
-                       Boolean useDescr, Boolean exclZero, Boolean logarithmic, Boolean keepRecords,
+                       boolean useDescr, boolean exclZero, boolean logarithmic, boolean keepRecords,
                        String yaxisMinimum, String yaxisMaximum, String csvFileName,
                        List<CSVSeries> csvSeries, List<PropertiesSeries> propertiesSeries,
                        List<XMLSeries> xmlSeries) {
@@ -114,19 +114,19 @@ public class PlotBuilder extends Builder implements SimpleBuildStep {
         return style;
     }
 
-    public Boolean getUseDescr() {
+    public boolean getUseDescr() {
         return useDescr;
     }
 
-    public Boolean getExclZero() {
+    public boolean getExclZero() {
         return exclZero;
     }
 
-    public Boolean getLogarithmic() {
+    public boolean getLogarithmic() {
         return logarithmic;
     }
 
-    public Boolean getKeepRecords() {
+    public boolean getKeepRecords() {
         return keepRecords;
     }
 
@@ -159,10 +159,7 @@ public class PlotBuilder extends Builder implements SimpleBuildStep {
                         TaskListener listener) {
         List<Plot> plots = new ArrayList<>();
         Plot plot = new Plot(title, yaxis, group, numBuilds, csvFileName, style,
-                useDescr != null && useDescr,
-                keepRecords != null && keepRecords,
-                exclZero != null && exclZero,
-                logarithmic != null && logarithmic,
+                useDescr, keepRecords, exclZero, logarithmic,
                 yaxisMinimum, yaxisMaximum);
         plot.series = series;
         plot.addBuild(build, listener.getLogger(), workspace);

--- a/src/main/java/hudson/plugins/plot/PlotBuilder.java
+++ b/src/main/java/hudson/plugins/plot/PlotBuilder.java
@@ -159,7 +159,11 @@ public class PlotBuilder extends Builder implements SimpleBuildStep {
                         TaskListener listener) {
         List<Plot> plots = new ArrayList<>();
         Plot plot = new Plot(title, yaxis, group, numBuilds, csvFileName, style,
-                useDescr, keepRecords, exclZero, logarithmic, yaxisMinimum, yaxisMaximum);
+                useDescr != null && useDescr,
+                keepRecords != null && keepRecords,
+                exclZero != null && exclZero,
+                logarithmic != null && logarithmic,
+                yaxisMinimum, yaxisMaximum);
         plot.series = series;
         plot.addBuild(build, listener.getLogger(), workspace);
         plots.add(plot);

--- a/src/main/java/hudson/plugins/plot/PlotBuilder.java
+++ b/src/main/java/hudson/plugins/plot/PlotBuilder.java
@@ -159,7 +159,7 @@ public class PlotBuilder extends Builder implements SimpleBuildStep {
                         TaskListener listener) {
         List<Plot> plots = new ArrayList<>();
         Plot plot = new Plot(title, yaxis, group, numBuilds, csvFileName, style,
-                false, false, false, false, yaxisMinimum, yaxisMaximum);
+                useDescr, keepRecords, exclZero, logarithmic, yaxisMinimum, yaxisMaximum);
         plot.series = series;
         plot.addBuild(build, listener.getLogger(), workspace);
         plots.add(plot);


### PR DESCRIPTION
Jira: https://issues.jenkins-ci.org/browse/JENKINS-48887

### Steps to reproduce or how to test
1. In scripted pipeline tried to use "logarithmic" for {{plot}} step call: 
```
plot(group: 'Build Pipeline KPIs', title: 'KPIs',
        csvFileName: 'plot-build-pipeline-kpis.csv',
        csvSeries: [[file: csvFilename, inclusionFlag: 'OFF', url: "${env.JOB_URL}%build%/"]],
        style: 'line', yaxis: 'Time [s]', logarithmic: true,
        keepRecords: false)
```
2. But plot is always/still using linear scale

### Screenshots
After: 
![grafik](https://user-images.githubusercontent.com/145182/34819298-a2b112ba-f6bd-11e7-9408-ea5436dd43b6.png)
(Please note that in this screenshot I have already used the "log10" scale referenced in https://issues.jenkins-ci.org/browse/JENKINS-48888)

This is using "exp" scale:
![grafik](https://user-images.githubusercontent.com/145182/34821655-c4cfd56e-f6c4-11e7-9778-f90518b08b3f.png)


### What has been done
See file change: Hard-coded `false` was used for all four flags.

Mind that the flags are not primitive `boolean`s, but `Boolean`s with default value null and therefore requires e.g. `useDescr != null && useDescr` instead of just `useDescr` to prevent an NPE. => Maybe the flag fields do not have to be `Boolean` objects, but can be primitive `boolean`s (with `true`/`false` initialization) instead? Then these slightly complex/confusing expressions are obsolete...