### PR TITLE
[JENKINS-50924] Fix chart style value comparison

### DIFF
--- a/src/main/java/hudson/plugins/plot/Plot.java
+++ b/src/main/java/hudson/plugins/plot/Plot.java
@@ -299,9 +299,9 @@ public class Plot implements Comparable<Plot> {
         LINE("line"),
         LINE_3D("line3d"),
         LINE_SIMPLE("lineSimple"),
-        STACKED_AREA("stackedarea"),
-        STACKED_BAR("stackedbar"),
-        STACKED_BAR_3D("stackedbar3d"),
+        STACKED_AREA("stackedArea"),
+        STACKED_BAR("stackedBar"),
+        STACKED_BAR_3D("stackedBar3d"),
         WATERFALL("waterfall");
 
         private final String name;
@@ -312,7 +312,7 @@ public class Plot implements Comparable<Plot> {
 
         static ChartStyle forName(String name) {
             for (ChartStyle chartStyle : ChartStyle.values()) {
-                if (name.equals(chartStyle.name)) {
+                if (name.equalsIgnoreCase(chartStyle.name)) {
                     return chartStyle;
                 }
             }

--- a/src/main/resources/hudson/plugins/plot/PlotBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/plot/PlotBuilder/config.jelly
@@ -39,8 +39,8 @@
                     <f:option value="lineSimple" selected="${plot.style=='lineSimple'}">${%Line simple}</f:option>
                     <f:option value="line3d" selected="${plot.style=='line3d'}">${%Line 3D}</f:option>
                     <f:option value="stackedArea" selected="${plot.style=='stackedArea'}">${%Stacked Area}</f:option>
-                    <f:option value="stackedbar" selected="${plot.style=='stackedbar'}">${%Stacked Bar}</f:option>
-                    <f:option value="stackedbar3d" selected="${plot.style=='stackedbar3d'}">${%Stacked Bar 3D}
+                    <f:option value="stackedBar" selected="${plot.style=='stackedBar'}">${%Stacked Bar}</f:option>
+                    <f:option value="stackedBar3d" selected="${plot.style=='stackedBar3d'}">${%Stacked Bar 3D}
                     </f:option>
                     <f:option value="waterfall" selected="${plot.style=='waterfall'}">${%Waterfall}</f:option>
                 </select>


### PR DESCRIPTION
<!-- Link to Jira ticket, https://issues.jenkins-ci.org
     good to have, but optional
 -->
Jira: [JENKINS-50924](https://issues.jenkins-ci.org/browse/JENKINS-50924)

<!-- Comment:
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * JIRA issues for minor improvements are not mandatory.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
 * Issue ID should be included in PR name (e.g. "[JENKINS-XXXXX] Add feature X.Y.Z".
-->

### What has been done
1. Fixed chart style value comparison

### How to test
1. Generate plot with any data and make sure `stackedArea` plot is rendered correctly
