### PR TITLE
Update values table CSS style and number formatting

### DIFF
--- a/src/main/java/hudson/plugins/plot/PlotReport.java
+++ b/src/main/java/hudson/plugins/plot/PlotReport.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.text.NumberFormat;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -72,6 +73,23 @@ public class PlotReport {
     // called from PlotReport/index.jelly
     public List<Plot> getPlots() {
         return plots;
+    }
+
+    // called from PlotReport/index.jelly
+    public String formatNumber(String number) {
+        String formatted;
+
+        try {
+            formatted = NumberFormat.getIntegerInstance().format(Integer.parseInt(number));
+        } catch (NumberFormatException e) {
+            try {
+                formatted = NumberFormat.getNumberInstance().format(Double.parseDouble(number));
+            } catch (NumberFormatException e2) {
+                return number;
+            }
+        }
+
+        return formatted;
     }
 
     // called from PlotReport/index.jelly

--- a/src/main/resources/hudson/plugins/plot/PlotReport/index.jelly
+++ b/src/main/resources/hudson/plugins/plot/PlotReport/index.jelly
@@ -9,6 +9,23 @@
   
   <d:taglib uri="chart">
     <d:tag name="chart">
+      <style>
+      table.valuesTable {
+        text-align: right; border: 2px solid gray; border-collapse: collapse;
+      }
+      table.valuesTable tr {
+        border: 1px solid lightgray;
+      }
+      table.valuesTable th {
+        border: 1px solid gray;
+        background-color: #eee;
+        padding:.2em;
+      }
+      table.valuesTable td {
+        border: 1px solid lightgray;
+        padding:.2em;
+      }
+      </style>
       <div id="${id}" style="margin-top: 2em">
         <div align="right" style="width:750px">
           <a href="#top"><img src="${rootURL}/images/24x24/up.gif"/>${%top}</a>
@@ -16,7 +33,7 @@
         <j:if test="${it.getDisplayTableFlag(index)}">
           <div>
           <p>
-          <table border="1">
+          <table class="valuesTable">
           <j:forEach var="tuple" items="${it.getTable(index)}" varStatus="loopStat3">
             <tr>
             <j:forEach var="col" items="${tuple}">
@@ -24,7 +41,7 @@
                 <th> ${col} </th>
               </j:if>
               <j:if test="${loopStat3.index>0}">
-                <td> ${col} </td>
+                <td> ${it.formatNumber(col)} </td>
               </j:if>
             </j:forEach>
             </tr>


### PR DESCRIPTION
### What has been done
1. Added internal CSS section to the *jelly* file and added style the values table.
2. Format the numbers in the table for improved readability

### Screenshots

| Before        | After           | 
| ------------- |:-------------:| 
| <img width="773" alt="screen shot 2018-05-15 at 16 00 05" src="https://user-images.githubusercontent.com/4147484/40077371-c21472e8-5881-11e8-8f0d-c79542be60d7.png">      | <img width="853" alt="screen shot 2018-05-15 at 15 48 27" src="https://user-images.githubusercontent.com/4147484/40077372-c230288a-5881-11e8-87fe-7c657fe61be7.png"> | 

### How to test
1. View plot with values table

### Checklist

- [x] Git commits follow [best practices](https://chris.beams.io/posts/git-commit/) <!-- mandatory -->
- [x] Build passes in Jenkins <!-- mandatory -->
- [ ] Appropriate tests or explanation to why this change has no tests <!-- mandatory -->
- [ ] JIRA issue is well described (problem explanation, steps to reproduce, screenshots) <!-- optional -->
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

