### PR TITLE
Fix codecov coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,2 @@
 codecov:
-  token: secret:GueNwtYl20me1u0wkb6Wxgq+Pb7Zfp0AyCSGb5qPFhSO9kOAZGCeUBQucko8sL2S9jrv8vtdoWpcQAM5MPS/333DiX6mkicHPdLi4WYpRzk=
+  token: c406d25e-1313-4f6a-9b24-2d0396210f15

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ def platform = 'linux'
 buildPlugin(platforms: [platform])
 
 node(platform) {
-    stage("Upload coverage") {
+    stage("Calculate & upload coverage") {
         infra.checkout(params.containsKey('repo') ? params.repo : null)
         infra.runWithMaven("mvn -P enable-jacoco test jacoco:prepare-agent jacoco:report")
         sh "curl -s https://codecov.io/bash | bash -s - -K"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ buildPlugin(platforms: ['linux'])
 
 node {
     stage("Upload coverage") {
+        infra.checkout(params.containsKey('repo') ? params.repo : null)
         infra.runWithMaven("mvn -P enable-jacoco verify jacoco:prepare-agent jacoco:report")
         sh "curl -s https://codecov.io/bash | bash -s - -K"
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,7 @@ buildPlugin(platforms: ['linux'])
 
 node {
     stage("Upload coverage") {
-        // no need to execute tests as they were executed already
-        infra.runWithMaven("mvn -P enable-jacoco jacoco:prepare-agent jacoco:report")
+        infra.runWithMaven("mvn -P enable-jacoco verify jacoco:prepare-agent jacoco:report")
         sh "curl -s https://codecov.io/bash | bash -s - -K"
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,8 @@
-buildPlugin(platforms: ['linux'])
+def platform = 'linux'
 
-node {
+buildPlugin(platforms: [platform])
+
+node(platform) {
     stage("Upload coverage") {
         infra.checkout(params.containsKey('repo') ? params.repo : null)
         infra.runWithMaven("mvn -P enable-jacoco test jacoco:prepare-agent jacoco:report")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ buildPlugin(platforms: ['linux'])
 node {
     stage("Upload coverage") {
         infra.checkout(params.containsKey('repo') ? params.repo : null)
-        infra.runWithMaven("mvn -P enable-jacoco verify jacoco:prepare-agent jacoco:report")
+        infra.runWithMaven("mvn -P enable-jacoco test jacoco:prepare-agent jacoco:report")
         sh "curl -s https://codecov.io/bash | bash -s - -K"
     }
 }


### PR DESCRIPTION
### What has been done
1. Fixed codecov coverage upload by using plain token instead of encrypted version (not supported yet, contacted codecov support)
2. Fixed code coverage calculation by making a checkout and executing tests in "Calculate & upload coverage" stage. It runs on a separate node and has no workspace stashed from `buildPlugin()` steps.

### How to test
1. Check CI job and make sure jacoco reports are uploaded to codecov
