### PR TITLE
Remove hardcoded codecov token

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,0 @@
-codecov:
-  token: c406d25e-1313-4f6a-9b24-2d0396210f15

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 def platform = 'linux'
 
-buildPlugin(platforms: [platform])
+buildPlugin(platforms: [platform], tests: [skip: true])
 
 node(platform) {
     stage("Calculate & upload coverage") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,8 @@ node(platform) {
     stage("Calculate & upload coverage") {
         infra.checkout(params.containsKey('repo') ? params.repo : null)
         infra.runWithMaven("mvn -P enable-jacoco test jacoco:prepare-agent jacoco:report")
-        sh "curl -s https://codecov.io/bash | bash -s - -K"
+        withCredentials([string(credentialsId: 'CODECOV_TOKEN', variable: 'CODECOV_TOKEN')]) {
+            sh "curl -s https://codecov.io/bash | bash -s - -K"
+        }
     }
 }


### PR DESCRIPTION
### What has been done
1. Remove hardcoded codecov token in favor of environment variable `CODECOV_TOKEN` set on ci.jenkins.io (thanks @rtyler)

### How to test
1. Make sure CI passes and coverage is uploaded to codecov.io
