### PR TITLE
Add back test for BOOLEAN node type

### DIFF
--- a/src/test/java/hudson/plugins/plot/XMLSeriesTest.java
+++ b/src/test/java/hudson/plugins/plot/XMLSeriesTest.java
@@ -154,6 +154,21 @@ public class XMLSeriesTest extends SeriesTestCase {
     }
 
     @Test
+    public void testXMLSeriesBoolean() {
+        // Create a new XML series.
+        String xpath = "//testcase[@name='testOne']";
+        XMLSeries series = new XMLSeries(TEST_XML_FILE, xpath, "BOOLEAN", null);
+
+        // test the basic subclass properties.
+        testSeries(series, TEST_XML_FILE, "", "xml");
+
+        // load the series.
+        List<PlotPoint> points = series.loadSeries(workspaceRootDir, 0, System.out);
+        assertNotNull(points);
+        testPlotPoints(points, 1);
+    }
+
+    @Test
     public void testXMLSeriesNumber() {
         // Create a new XML series.
         String xpath =


### PR DESCRIPTION
### What has been done
1. Added back test for `BOOLEAN` node type. It was removed in #52. `@Ignore` annotation on that test confused me, looks like that test was still included (because of base `HudsonTestSuite`? 🤔 idk, nvm).

### Checklist

- [x] Git commits follow [best practices](https://chris.beams.io/posts/git-commit/) <!-- mandatory -->
- [x] Build passes in Jenkins <!-- mandatory -->
- [x] Appropriate tests or explanation to why this change has no tests <!-- mandatory -->
- [ ] JIRA issue is well described (problem explanation, steps to reproduce, screenshots) <!-- optional -->
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

