### PR TITLE
Support multiple CSV files in series

### DIFF
--- a/src/main/java/hudson/plugins/plot/CSVSeries.java
+++ b/src/main/java/hudson/plugins/plot/CSVSeries.java
@@ -126,7 +126,7 @@ public class CSVSeries extends Series {
         }
 
         for (FilePath seriesFile : seriesFiles) {
-            List<PlotPoint> seriesList = loadSeriesFile(seriesFile, buildNumber, logger);
+            List<PlotPoint> seriesList = loadSeriesFile(seriesFile, buildNumber);
             if (seriesList != null) {
                 if (ret != null) {
                     ret.addAll(seriesList);
@@ -139,8 +139,7 @@ public class CSVSeries extends Series {
         return ret;
     }
 
-    private List<PlotPoint> loadSeriesFile(FilePath seriesFile,
-                                           int buildNumber, PrintStream logger) {
+    private List<PlotPoint> loadSeriesFile(FilePath seriesFile, int buildNumber) {
         CSVReader reader = null;
         InputStream in = null;
         InputStreamReader inputReader = null;

--- a/src/main/java/hudson/plugins/plot/CSVSeries.java
+++ b/src/main/java/hudson/plugins/plot/CSVSeries.java
@@ -125,7 +125,8 @@ public class CSVSeries extends Series {
             return null;
         }
 
-        for (int index = 0; index < seriesFiles.length; index++) {
+        for (FilePath seriesFile : seriesFiles) {
+            List<PlotPoint> seriesList = loadSeriesFile(seriesFile, buildNumber, logger);
             List<PlotPoint> seriesList =
                 loadSeriesFile(seriesFiles[index], buildNumber, logger);
             if (seriesList != null) {

--- a/src/main/java/hudson/plugins/plot/CSVSeries.java
+++ b/src/main/java/hudson/plugins/plot/CSVSeries.java
@@ -127,8 +127,6 @@ public class CSVSeries extends Series {
 
         for (FilePath seriesFile : seriesFiles) {
             List<PlotPoint> seriesList = loadSeriesFile(seriesFile, buildNumber, logger);
-            List<PlotPoint> seriesList =
-                loadSeriesFile(seriesFiles[index], buildNumber, logger);
             if (seriesList != null) {
                 if (ret != null) {
                     ret.addAll(seriesList);

--- a/src/main/webapp/help-series.html
+++ b/src/main/webapp/help-series.html
@@ -9,5 +9,9 @@
   <a href='ws/'>workspace root</a>, that
   contains the data values for this series.
   The contents of this file depend on the series type selected below.
+  Multiple files can be specified using wildcard "*.csv" or
+  comma-separated "file1.csv, file2.csv" when the series type is csv.
+  Other series types will match only the first file matching a wildcard
+  pattern.
   Please see the series type for specific information on the contents.  
 </div>

--- a/src/test/java/hudson/plugins/plot/CSVSeriesTest.java
+++ b/src/test/java/hudson/plugins/plot/CSVSeriesTest.java
@@ -27,12 +27,12 @@ import static org.junit.Assert.fail;
 public class CSVSeriesTest extends SeriesTestCase {
     private static final Logger LOGGER = Logger.getLogger(CSVSeriesTest.class.getName());
 
-    private static final String[] FILES = {"test.csv", "test_trailing_spaces.csv", "test_trailing_semicolon.csv"};
-    private static final int[] LINES = {2, 3, 2};  // lines in the file including header
-    private static final int[] COLUMNS = {8, 3, 9};  // columns in the file
-    private static final int[] CORRECTED_COLUMNS = {8, 3, 8};  // corrected for the trailing comma case
-    private static final int[] TOTAL_POINTS = {8, 6, 8};  // total data points in the file
-    private static final String[] LAST_COLUMN_NAME = {"error %", "thing", "error %"};  // the label on the last column
+    private static final String[] FILES = {"test.csv", "test_trailing_spaces.csv", "test_trailing_semicolon.csv", "test_multiple*.csv"};
+    private static final int[] LINES = {2, 3, 2, 4};  // lines in the file including header
+    private static final int[] COLUMNS = {8, 3, 9, 2};  // columns in the file
+    private static final int[] CORRECTED_COLUMNS = {8, 3, 8, 2};  // corrected for the trailing comma case
+    private static final int[] TOTAL_POINTS = {8, 6, 8, 6};  // total data points in the file
+    private static final String[] LAST_COLUMN_NAME = {"error %", "thing", "error %", "bravo"};  // the label on the last column
 
     @Test
     public void testCSVSeriesWithNullExclusionValuesSetsDisplayTableFlag() {
@@ -153,19 +153,6 @@ public class CSVSeriesTest extends SeriesTestCase {
             IOUtils.closeQuietly(inputReader);
             IOUtils.closeQuietly(inputStream);
         }
-    }
-
-    @Test
-    public void testCSVSeriesMultipleFiles() {
-        // Create a new CSV series.
-        CSVSeries series = new CSVSeries("*.csv", "http://localhost:8080/%name%/%index%/", "INCLUDE_BY_STRING", "Avg", false);
-
-        LOGGER.info("Created series " + series.toString());
-
-        // load the series.
-        List<PlotPoint> points = series.loadSeries(workspaceRootDir, 0, System.out);
-        LOGGER.info("Got " + points.size() + " plot points");
-        testPlotPoints(points, 2);  // Avg is found in 2 files, each containing 1 line
     }
 
 }

--- a/src/test/java/hudson/plugins/plot/CSVSeriesTest.java
+++ b/src/test/java/hudson/plugins/plot/CSVSeriesTest.java
@@ -157,17 +157,15 @@ public class CSVSeriesTest extends SeriesTestCase {
 
     @Test
     public void testCSVSeriesMultipleFiles() {
-        for (int index = 0; index < FILES.length; index++) {
-            // Create a new CSV series.
-            CSVSeries series = new CSVSeries("*.csv", "http://localhost:8080/%name%/%index%/", "INCLUDE_BY_STRING", "Avg", false);
+        // Create a new CSV series.
+        CSVSeries series = new CSVSeries("*.csv", "http://localhost:8080/%name%/%index%/", "INCLUDE_BY_STRING", "Avg", false);
 
-            LOGGER.info("Created series " + series.toString());
+        LOGGER.info("Created series " + series.toString());
 
-            // load the series.
-            List<PlotPoint> points = series.loadSeries(workspaceRootDir, 0, System.out);
-            LOGGER.info("Got " + points.size() + " plot points");
-            testPlotPoints(points, 2);  // Avg is found in 2 files, each containing 1 line
-        }
+        // load the series.
+        List<PlotPoint> points = series.loadSeries(workspaceRootDir, 0, System.out);
+        LOGGER.info("Got " + points.size() + " plot points");
+        testPlotPoints(points, 2);  // Avg is found in 2 files, each containing 1 line
     }
 
 }

--- a/src/test/java/hudson/plugins/plot/CSVSeriesTest.java
+++ b/src/test/java/hudson/plugins/plot/CSVSeriesTest.java
@@ -154,5 +154,4 @@ public class CSVSeriesTest extends SeriesTestCase {
             IOUtils.closeQuietly(inputStream);
         }
     }
-
 }

--- a/src/test/java/hudson/plugins/plot/CSVSeriesTest.java
+++ b/src/test/java/hudson/plugins/plot/CSVSeriesTest.java
@@ -154,4 +154,20 @@ public class CSVSeriesTest extends SeriesTestCase {
             IOUtils.closeQuietly(inputStream);
         }
     }
+
+    @Test
+    public void testCSVSeriesMultipleFiles() {
+        for (int index = 0; index < FILES.length; index++) {
+            // Create a new CSV series.
+            CSVSeries series = new CSVSeries("*.csv", "http://localhost:8080/%name%/%index%/", "INCLUDE_BY_STRING", "Avg", false);
+
+            LOGGER.info("Created series " + series.toString());
+
+            // load the series.
+            List<PlotPoint> points = series.loadSeries(workspaceRootDir, 0, System.out);
+            LOGGER.info("Got " + points.size() + " plot points");
+            testPlotPoints(points, 2);  // Avg is found in 2 files, each containing 1 line
+        }
+    }
+
 }

--- a/src/test/resources/test_multiple1.csv
+++ b/src/test/resources/test_multiple1.csv
@@ -1,0 +1,2 @@
+alpha,bravo
+2,4

--- a/src/test/resources/test_multiple2.csv
+++ b/src/test/resources/test_multiple2.csv
@@ -1,0 +1,3 @@
+alpha,bravo
+4,6
+6,8


### PR DESCRIPTION
Since the CSVSeries supports multiple data points anyway, allow a wildcard pattern to match multiple files and add them all to the same series.

<!-- Link to Jira ticket, https://issues.jenkins-ci.org
     good to have, but optional
Jira: [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX)
 -->

<!-- Comment:
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * JIRA issues for minor improvements are not mandatory.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
 * Issue ID should be included in PR name (e.g. "[JENKINS-XXXXX] Add feature X.Y.Z".

### What has been done
1.
2.
-->

<!-- optional. Should be removed if not applicable
### Screenshots

Before | After
:-: | :-:
| |
-->

### How to test
Specify a pattern to a CSV file which matches multiple files.
Note that a test was added to verify this.

### Checklist

- [x] Git commits follow [best practices](https://chris.beams.io/posts/git-commit/) <!-- mandatory -->
- [ ] Build passes in Jenkins <!-- mandatory -->
- [x] Appropriate tests or explanation to why this change has no tests <!-- mandatory -->
- [ ] JIRA issue is well described (problem explanation, steps to reproduce, screenshots) <!-- optional -->
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

