### PR TITLE
Add missing PlotBuild#getDescription() method

### DIFF
--- a/src/main/java/hudson/plugins/plot/PlotBuilder.java
+++ b/src/main/java/hudson/plugins/plot/PlotBuilder.java
@@ -175,6 +175,11 @@ public class PlotBuilder extends Builder implements SimpleBuildStep {
         this.yaxisMaximum = Util.fixEmptyAndTrim(yaxisMaximum);
     }
 
+    @CheckForNull
+    public String getDescription() {
+        return description;
+    }
+
     @DataBoundSetter
     public final void setDescription(@CheckForNull String description) {
         this.description = Util.fixEmptyAndTrim(description);


### PR DESCRIPTION
<!-- Link to Jira ticket, https://issues.jenkins-ci.org
     good to have, but optional
 -->
Jira: [JENKINS-61412](https://issues.jenkins-ci.org/browse/JENKINS-61412)


### What has been done
1. Added missing `PlotBuild#getDescription()` method

### How to test
1. Create pipeline job with sample `Jenkinsfile` and trigger the build
```
node {
    sh '''
    OUTFILE="test.csv";
    echo "Avg,Median,90,min,max,samples,errors,error %" >> $OUTFILE;
    echo "1234,1906,117,200,29,97560,1170,15" >> $OUTFILE;
    '''
        
    plot csvFileName: "plot-1", csvSeries: [[displayTableFlag: true, exclusionValues: '', file: "test.csv", inclusionFlag: 'OFF', url: '']], exclZero: false, group: "group 1", keepRecords: false, logarithmic: false, numBuilds: '', style: 'line', title: "title 1", useDescr: false, yaxis: 'Value', yaxisMaximum: '', yaxisMinimum: ''
}
```
2. Make sure no `UnsupportedOperationException` is thrown to logs (check logs at `JENKINS_URL/log/all`)
```
WARNING o.j.p.s.d.DescribableParameter#uncoerce: failed to uncoerce hudson.plugins.plot.PlotBuilder@4bf77f69
java.lang.UnsupportedOperationException: no public field ‘description’ (or getter method) found in class hudson.plugins.plot.PlotBuilder
``` 

### Checklist

- [x] Git commits follow [best practices](https://chris.beams.io/posts/git-commit/) <!-- mandatory -->
- [x] Build passes in Jenkins <!-- mandatory -->
- [ ] Appropriate tests or explanation to why this change has no tests <!-- mandatory -->
- [x] JIRA issue is well described (problem explanation, steps to reproduce, screenshots) <!-- optional -->
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

