### PR TITLE
Add Release Drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,5 @@
+# see https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+_extends: .github
+version-template: $MAJOR.$MINOR.$PATCH
+name-template: $NEXT_PATCH_VERSION
+tag-template: plot-$NEXT_PATCH_VERSION


### PR DESCRIPTION
### What has been done
1. Added `Release Drafter` integration.
Read more at https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc and https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/.
2. Configured GitHub labels to be used for Pull Requests for automatic release generation by Release Drafter
    <img src="https://user-images.githubusercontent.com/3036347/76937955-70b34480-68fe-11ea-8294-54ef64821c61.png" width="200" height="200" />
3. Manually created releases for versions published after [old Changelog](https://wiki.jenkins.io/pages/viewpage.action?pageId=2752526) deprecation under https://github.com/jenkinsci/plot-plugin/releases. Followed the same `Release Drafter` format.

### TODO
- ~[ ] Backup [old Changelog](https://wiki.jenkins.io/pages/viewpage.action?pageId=2752526) into current repository as markdown file~ 
Will be addressed in separate PR.

### How to test
1. Will be tested during next release. `Release Drafter` should create draft release and automatically include labeled PRs

### Checklist

- [x] Git commits follow [best practices](https://chris.beams.io/posts/git-commit/) <!-- mandatory -->
- [x] Build passes in Jenkins <!-- mandatory -->
- [ ] Appropriate tests or explanation to why this change has no tests <!-- mandatory -->
- [x] JIRA issue is well described (problem explanation, steps to reproduce, screenshots) <!-- optional -->
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

