### PR TITLE
Do not throw exception when Y-axis min/max properties are not set

### DIFF
--- a/src/main/java/hudson/plugins/plot/Plot.java
+++ b/src/main/java/hudson/plugins/plot/Plot.java
@@ -399,7 +399,7 @@ public class Plot implements Comparable<Plot> {
             try {
                 result = Double.parseDouble(input);
             } catch (NumberFormatException nfe) {
-                LOGGER.log(Level.INFO, "Failed to parse Double value from String."
+                LOGGER.log(Level.FINE, "Failed to parse Double value from String."
                         + " Not a problem, result already set", nfe);
             }
         }

--- a/src/main/java/hudson/plugins/plot/Plot.java
+++ b/src/main/java/hudson/plugins/plot/Plot.java
@@ -395,11 +395,11 @@ public class Plot implements Comparable<Plot> {
 
     public Double getDoubleFromString(String input) {
         Double result = null;
-        if (input != null) {
+        if (!StringUtils.isEmpty(input)) {
             try {
                 result = Double.parseDouble(input);
             } catch (NumberFormatException nfe) {
-                LOGGER.log(Level.FINE, "Failed to parse Double value from String."
+                LOGGER.log(Level.INFO, "Failed to parse Double value from String."
                         + " Not a problem, result already set", nfe);
             }
         }


### PR DESCRIPTION
Jira: [JENKINS-50363](https://issues.jenkins-ci.org/browse/JENKINS-50363)

Fix the GetDoubleFromString conversion exception (INFO --> FINE) when YaxisMin/Max are not set

It is a feature not to configure YaxisMinimum/Maximum. In that case, String values are defaulted to null.
As DoubleFromString convertion is called also within hasYaxisMinimum() / hasYaxisMaximum() function (strange pattern), so convertion failure is a feature and should not raise an exception with INFO level, which is bloating Jenkins logs