### PR TITLE
Modernise pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <artifactId>plot</artifactId>
   <packaging>hpi</packaging>
   <name>Plot plugin</name>
-  <version>2.1.8-SNAPSHOT</version>
+  <version>2.1.8</version>
   <url>https://github.com/jenkinsci/plot-plugin</url>
 
   <developers>
@@ -171,7 +171,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/plot-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/plot-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/plot-plugin</url>
-    <tag>HEAD</tag>
+    <tag>plot-2.1.8</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,16 +4,27 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.32</version>
+    <version>4.6</version>
     <relativePath />
   </parent>
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.0</jenkins.version>
-    <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
-    <java.level>7</java.level>
+    <jenkins.version>2.204.6</jenkins.version>
+    <java.level>8</java.level>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.204.x</artifactId>
+        <version>11</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <artifactId>plot</artifactId>
   <packaging>hpi</packaging>
@@ -41,17 +52,14 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
-      <version>1.3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.20</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.12</version>
     </dependency>
     <dependency>
       <groupId>net.sf.opencsv</groupId>
@@ -62,52 +70,21 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>2.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.40</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>2.8</version>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Satisfy upper bounds dependency warnings -->
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>structs</artifactId>
-      <version>1.10</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-support</artifactId>
-      <version>2.14</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-api</artifactId>
-      <version>2.20</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-step-api</artifactId>
-      <version>2.12</version>
-      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -118,26 +95,6 @@
            (xml-apis.jar has an old version of the DOM.  
            Eclipse tends to get the classpath order wrong)
       -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-eclipse-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>xml-apis:xml-apis</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-gitexe</artifactId>
-            <version>1.9.5</version>
-          </dependency>
-        </dependencies>
-      </plugin>
       <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.16</version>
@@ -173,25 +130,5 @@
     <url>https://github.com/jenkinsci/plot-plugin</url>
     <tag>HEAD</tag>
   </scm>
-
-  <distributionManagement>
-    <repository>
-      <id>maven.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/releases/</url>
-    </repository>
-  </distributionManagement>
-
-  <repositories>
-    <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
-    </pluginRepository>
-  </pluginRepositories>
+  
 </project>  

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.15</version>
+    <version>4.16</version>
     <relativePath />
   </parent>
 
@@ -20,7 +20,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.222.x</artifactId>
-        <version>24</version>
+        <version>25</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <artifactId>plot</artifactId>
   <packaging>hpi</packaging>
   <name>Plot plugin</name>
-  <version>2.1.8</version>
+  <version>2.1.9-SNAPSHOT</version>
   <url>https://github.com/jenkinsci/plot-plugin</url>
 
   <developers>
@@ -171,7 +171,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/plot-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/plot-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/plot-plugin</url>
-    <tag>plot-2.1.8</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.204.6</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -19,8 +19,8 @@
       <!-- https://github.com/jenkinsci/bom -->
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.204.x</artifactId>
-        <version>11</version>
+        <artifactId>bom-2.222.x</artifactId>
+        <version>24</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.7</version>
+    <version>4.15</version>
     <relativePath />
   </parent>
 
@@ -120,6 +120,20 @@
       </plugin>
     </plugins>
   </build>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <scm>
     <connection>scm:git:ssh://github.com/jenkinsci/plot-plugin.git</connection>


### PR DESCRIPTION
### What has been done
1. Modernise pom by updating to newer versions of dependencies and required Jenkins version
	- Jenkins plugins 2.32 -> 4.7
	- Jenkins 2.0 -> 2.204.6
2. Update required Java version 7 -> 8
3. Use https://github.com/jenkinsci/bom to satisfy upper boundary dependencies and no longer manage explicit versions but rather rely on 


### How to test
1. Make sure project compiles and CI is 🟢
2. Perform the plugin update to new version packaged from current PR to smoke test plotting capabilities after migration to Java 8
3. Make sure Jenkins log doesn't throw any new errors/warnings

### Checklist

- [ ] Git commits follow [best practices](https://chris.beams.io/posts/git-commit/) <!-- mandatory -->
- [ ] Build passes in Jenkins <!-- mandatory -->
- [ ] Appropriate tests or explanation to why this change has no tests <!-- mandatory -->
- [x] Pull Request is marked with appropriate label (see `.github/release-drafter.yml`) <!-- mandatory -->
- [ ] JIRA issue is well described (problem explanation, steps to reproduce, screenshots) <!-- optional -->
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

