### PR TITLE
[SECURITY-2220] Escape plot description

### DIFF
--- a/src/main/resources/hudson/plugins/plot/PlotReport/index.jelly
+++ b/src/main/resources/hudson/plugins/plot/PlotReport/index.jelly
@@ -54,7 +54,7 @@
         <div style="width:750px">
           <j:if test="${it.getPlotDescription(index) != null}">
             <j:if test="${!it.getPlotDescription(index).isEmpty()}">
-              <b>Description</b>: <j:out value="${it.getPlotDescription(index)}"/>
+              <b>Description</b>: <span>${it.getPlotDescription(index)}</span>
             </j:if>
           </j:if>
         </div>


### PR DESCRIPTION
Naive approach to address [SECURITY-2220](https://www.jenkins.io/security/advisory/2022-06-30/#SECURITY-2220).

`<j:out … />` seems to ignore _escape-by-default_, using a simple `<span>…</span>` instead escapes the value.

@wadeck @daniel-beck 


<!-- Comment:
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * JIRA issues for minor improvements are not mandatory.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
 * Issue ID should be included in PR name (e.g. "[JENKINS-XXXXX] Add feature X.Y.Z".
-->

### What has been done
1. Escaping added to prevent a security issue


### How to test
1. Use Plot description that needs escaping


### Checklist

- [ ] Git commits follow [best practices](https://chris.beams.io/posts/git-commit/) <!-- mandatory -->
- [ ] Build passes in Jenkins <!-- mandatory -->
- [ ] Appropriate tests or explanation to why this change has no tests <!-- mandatory -->
- [ ] Pull Request is marked with appropriate label (see `.github/release-drafter.yml`) <!-- mandatory -->
- [ ] JIRA issue is well described (problem explanation, steps to reproduce, screenshots) <!-- optional -->
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs