### PR TITLE
Remove codecov reporting from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,1 @@
 buildPlugin(platforms: ['linux', 'windows'])
-
-node('linux') {
-    stage("Calculate & upload coverage") {
-        infra.checkout(params.containsKey('repo') ? params.repo : null)
-        infra.runWithMaven("mvn -P enable-jacoco test jacoco:prepare-agent jacoco:report")
-        withCredentials([string(credentialsId: 'CODECOV_TOKEN', variable: 'CODECOV_TOKEN')]) {
-            sh "curl -s https://codecov.io/bash | bash -s - -K"
-        }
-    }
-}


### PR DESCRIPTION
## Remove codecov reporting from Jenkinsfile

Adopt null pointer exception during checkout phase.  Prefer the code coverage reporting that is included in `buildPlugin` and the current toolchain.

### What is the goal

1. Resume working builds on ci.jenkins.io [![Build Status](https://ci.jenkins.io/job/Plugins/job/plot-plugin/job/master/badge/icon?subject=Master%20build)](https://ci.jenkins.io/job/Plugins/job/plot-plugin/job/master/)

### How to test

1. Confirm the build passes for this pull request on this pull request [![Build Status](https://ci.jenkins.io/job/Plugins/job/plot-plugin/view/change-requests/job/PR-75/badge/icon?subject=PR-75%20build)](https://ci.jenkins.io/job/Plugins/job/plot-plugin/view/change-requests/job/PR-75/)

### Checklist

- [x] Git commits follow [best practices](https://chris.beams.io/posts/git-commit/) <!-- mandatory -->
- [ ] Build passes in Jenkins <!-- mandatory -->
- [x] Appropriate tests or explanation to why this change has no tests <!-- mandatory -->
- [ ] Pull Request is marked with appropriate label (see `.github/release-drafter.yml`) <!-- mandatory -->
- ~~JIRA issue is well described (problem explanation, steps to reproduce, screenshots)~~
- ~~For dependency updates: links to external changelogs and, if possible, full diffs~~

