### PR TITLE
Require newer core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.332.4</jenkins.version>
+    <jenkins.version>2.346.3</jenkins.version>
   </properties>
 
   <dependencyManagement>
@@ -18,7 +18,7 @@
       <!-- https://github.com/jenkinsci/bom -->
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
+        <artifactId>bom-2.346.x</artifactId>
         <version>1607.va_c1576527071</version>
         <scope>import</scope>
         <type>pom</type>


### PR DESCRIPTION
### What has been done
1. I have updated the minimum required Jenkins version by setting a `jenkins.version` value in the properties section of the `pom.xml` file:
2. As the plugin is already using the plugin bill of materials, I have then updated it with the matching `artifactId` for the minimum required Jenkins version. 

### Checklist

- [X] Git commits follow [best practices](https://chris.beams.io/posts/git-commit/) <!-- mandatory -->
- [X] Build passes in Jenkins <!-- mandatory -->
- [X] Appropriate tests or explanation to why this change has no tests <!-- mandatory -->
- ~~Pull Request is marked with appropriate label (see `.github/release-drafter.yml`) <!-- mandatory -->~~
- ~~JIRA issue is well described (problem explanation, steps to reproduce, screenshots) <!-- optional -->~~
- ~~For dependency updates: links to external changelogs and, if possible, full diffs~~

