### PR TITLE
Use opencsv 5.7.1, not 2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,9 @@
       <artifactId>workflow-step-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>net.sf.opencsv</groupId>
+      <groupId>com.opencsv</groupId>
       <artifactId>opencsv</artifactId>
-      <version>2.4</version>
+      <version>5.7.1</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/hudson/plugins/plot/CSVSeries.java
+++ b/src/main/java/hudson/plugins/plot/CSVSeries.java
@@ -5,7 +5,8 @@
  */
 package hudson.plugins.plot;
 
-import au.com.bytecode.opencsv.CSVReader;
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
@@ -255,7 +256,7 @@ public class CSVSeries extends Series {
             }
 
             return ret;
-        } catch (IOException ioe) {
+        } catch (CsvValidationException | IOException ioe) {
             LOGGER.log(Level.SEVERE, "Exception loading series", ioe);
         } finally {
             if (reader != null) {

--- a/src/main/java/hudson/plugins/plot/Plot.java
+++ b/src/main/java/hudson/plugins/plot/Plot.java
@@ -5,8 +5,9 @@
  */
 package hudson.plugins.plot;
 
-import au.com.bytecode.opencsv.CSVReader;
-import au.com.bytecode.opencsv.CSVWriter;
+import com.opencsv.CSVReader;
+import com.opencsv.CSVWriter;
+import com.opencsv.exceptions.CsvValidationException;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
@@ -948,7 +949,7 @@ public class Plot implements Comparable<Plot> {
             while ((nextLine = reader.readNext()) != null) {
                 rawPlotData.add(nextLine);
             }
-        } catch (IOException ioe) {
+        } catch (CsvValidationException | IOException ioe) {
             LOGGER.log(Level.SEVERE, "Exception reading plot file", ioe);
         } finally {
             if (reader != null) {

--- a/src/main/java/hudson/plugins/plot/PlotReport.java
+++ b/src/main/java/hudson/plugins/plot/PlotReport.java
@@ -4,7 +4,8 @@
  */
 package hudson.plugins.plot;
 
-import au.com.bytecode.opencsv.CSVReader;
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
 import hudson.model.AbstractProject;
 import hudson.model.Job;
 import java.io.File;
@@ -200,7 +201,7 @@ public class PlotReport {
                     tableRow.add(StringUtils.EMPTY);
                 }
             }
-        } catch (IOException ioe) {
+        } catch (CsvValidationException | IOException ioe) {
             LOGGER.log(Level.SEVERE, "Exception reading csv file", ioe);
         } finally {
             if (reader != null) {

--- a/src/test/java/hudson/plugins/plot/CSVReaderTest.java
+++ b/src/test/java/hudson/plugins/plot/CSVReaderTest.java
@@ -5,7 +5,8 @@
 
 package hudson.plugins.plot;
 
-import au.com.bytecode.opencsv.CSVReader;
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
 import hudson.FilePath;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
@@ -82,7 +83,7 @@ public class CSVReaderTest extends SeriesTestCase {
                 }
                 assertEquals("Line count is not equal " + lineNum + " expected " + LINES[index],
                         LINES[index], lineNum);
-            } catch (IOException | InterruptedException e) {
+            } catch (CsvValidationException | IOException | InterruptedException e) {
                 fail("Exception " + e);
             } finally {
                 try {

--- a/src/test/java/hudson/plugins/plot/CSVSeriesTest.java
+++ b/src/test/java/hudson/plugins/plot/CSVSeriesTest.java
@@ -4,7 +4,8 @@
  */
 package hudson.plugins.plot;
 
-import au.com.bytecode.opencsv.CSVReader;
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
 import hudson.FilePath;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
@@ -417,6 +418,8 @@ public class CSVSeriesTest extends SeriesTestCase {
 
             LOGGER.info("Got " + headerLine.length + " columns");
             return headerLine.length;
+        } catch (CsvValidationException invalid) {
+            throw new IOException(invalid);
         } finally {
             try {
                 if (csvReader != null) {


### PR DESCRIPTION
## Use opencsv 5.7.1 (2022), not 2.4 (2012)

### What has been done
1. Update opencsv dependency to use the replacement com.opencsv

No additional tests added because the change should be a functionally equivalent replacement.

### How to test
1. Install and run the plot plugin with a CSV data file
2. Confirm the CSV plot is rendered correctly
3. In case of errors, confirm errors match the previous release

### Checklist

- [x] Git commits follow [best practices](https://chris.beams.io/posts/git-commit/) <!-- mandatory -->
- [x] Build passes in Jenkins <!-- mandatory -->
- [x] Appropriate tests or explanation to why this change has no tests <!-- mandatory -->
- [x] Pull Request is marked with appropriate label (see `.github/release-drafter.yml`) <!-- mandatory -->
- [x] JIRA issue is well described (problem explanation, steps to reproduce, screenshots) <!-- optional -->

