### PR TITLE
Check dependencies monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "weekly" 
+      interval: "monthly"


### PR DESCRIPTION
Weekly is more frequent than necessary.

The plugin archetype recommends monthly.

### What has been done
1. Reduce update check from weekly to monthly so that maintainers only see new dependencies once a month

### How to test
1. Merge to the master branch
2. Confirm that the check runs only once a month

### Checklist

- [x] Git commits follow [best practices](https://chris.beams.io/posts/git-commit/) <!-- mandatory -->
- [x] Build passes in Jenkins <!-- mandatory -->
- [x] Appropriate tests or explanation to why this change has no tests <!-- mandatory -->
- [x] Pull Request is marked with appropriate label (see `.github/release-drafter.yml`) <!-- mandatory -->
- [x] For dependency updates: links to external changelogs and, if possible, full diffs
