### PR TITLE
Run parallel tests on ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(
+  forkCount: '1C', // Run parallel tests on ci.jenkins.io for lower costs, faster feedback
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 21],


### PR DESCRIPTION
## Run parallel tests on ci.jenkins.io

Parallel tests consistently run faster for this repository than running the tests in a single Java virtual machine.  Use a Java virtual machine per core when running on ci.jenkins.io.

### What has been done

1. Confirmed with multiple test runs on ci.jenkins.io (using Pipeline replay) that forkCount: '1C' consistently completes tests faster then the default setting


### How to test
1. Run with `mvn clean -DforkCount=1C verify`

### Checklist

- [x] Git commits follow [best practices](https://chris.beams.io/posts/git-commit/) <!-- mandatory -->
- [x] Build passes in Jenkins <!-- mandatory -->
- [x] Appropriate tests or explanation to why this change has no tests <!-- mandatory -->
- [x] Pull Request is marked with appropriate label (see `.github/release-drafter.yml`) <!-- mandatory -->
- [x] JIRA issue is well described (problem explanation, steps to reproduce, screenshots) <!-- optional -->
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

