### PR TITLE
Enable checkstyle for Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,16 +96,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.6.0</version>
-	<!-- enable this when the plugin requires Java 11 -->
-	<!--
         <dependencies>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.3.3</version>
+            <version>10.21.1</version>
           </dependency>
         </dependencies>
-	-->
         <executions>
           <execution>
             <id>checkstyle</id>


### PR DESCRIPTION
## Enable checkstyle for Java 11

Java 11 has been required since the plugin first required Jenkins 2.361 or later.  If we're going to use checkstyle, let's use the most recent checkstyle release.

### What has been done
1. Confirmed that checkstyle output is silent in a typical build
2. Will confirm that ci.jenkins.io checkstyle output is also silent

### How to test
1. Review checkstyle output on ci.jenkins.io

No automated tests because this is static analysis performed at build time.

### Checklist

- [x] Git commits follow [best practices](https://chris.beams.io/posts/git-commit/) <!-- mandatory -->
- [x] Build passes in Jenkins <!-- mandatory -->
- [x] Appropriate tests or explanation to why this change has no tests <!-- mandatory -->
- [x] Pull Request is marked with appropriate label (see `.github/release-drafter.yml`) <!-- mandatory -->
- [x] JIRA issue is well described (problem explanation, steps to reproduce, screenshots) <!-- optional -->
- [x] For dependency updates: links to external changelogs and, if possible, full diffs
