### PR TITLE
Replace outdated icons with analytics symbol

### DIFF
--- a/src/main/java/hudson/plugins/plot/MatrixPlotAction.java
+++ b/src/main/java/hudson/plugins/plot/MatrixPlotAction.java
@@ -66,7 +66,7 @@ public class MatrixPlotAction implements Action, StaplerProxy {
     }
 
     public String getIconFileName() {
-        return "graph.png";
+        return "symbol-analytics";
     }
 
     public String getUrlName() {

--- a/src/main/java/hudson/plugins/plot/PlotAction.java
+++ b/src/main/java/hudson/plugins/plot/PlotAction.java
@@ -39,7 +39,7 @@ public class PlotAction implements Action, StaplerProxy {
 
     @Override
     public String getIconFileName() {
-        return "graph.png";
+        return "symbol-analytics";
     }
 
     @Override

--- a/src/main/resources/hudson/plugins/plot/MatrixPlotAction/index.jelly
+++ b/src/main/resources/hudson/plugins/plot/MatrixPlotAction/index.jelly
@@ -9,7 +9,7 @@
   <l:layout title="${it.project.displayName} plots">
     <st:include it="${it.project}" page="sidepanel.jelly" />
     <l:main-panel>
-      <h1>${%Plot Groups}</h1>
+      <h1 class="page-headline">${%Plot Groups}</h1>
 
       <j:choose>
         <j:when test="${it.hasPlots()}">
@@ -18,7 +18,7 @@
           </p>
           <table>
             <j:forEach var="group" items="${it.originalGroups}">
-              <t:summary icon="icon-graph icon-md" href="${it.getUrlGroup(group)}/">
+              <t:summary icon="symbol-analytics icon-md" href="${it.getUrlGroup(group)}/">
                 ${group}
               </t:summary>
             </j:forEach>

--- a/src/main/resources/hudson/plugins/plot/PlotAction/index.jelly
+++ b/src/main/resources/hudson/plugins/plot/PlotAction/index.jelly
@@ -9,7 +9,7 @@
   <l:layout title="${it.job.displayName} plots">
     <st:include it="${it.job}" page="sidepanel.jelly" />
     <l:main-panel>
-      <h1>${%Plot Groups}</h1>
+      <h1 class="page-headline">${%Plot Groups}</h1>
 
       <j:choose>
         <j:when test="${it.hasPlots()}">
@@ -18,7 +18,7 @@
           </p>
           <table>
             <j:forEach var="group" items="${it.originalGroups}">
-              <t:summary icon="icon-graph icon-md" href="${it.getUrlGroup(group)}/">
+              <t:summary icon="symbol-analytics icon-md" href="${it.getUrlGroup(group)}/">
                 ${group}
               </t:summary>
             </j:forEach>

--- a/src/main/resources/hudson/plugins/plot/PlotReport/index.jelly
+++ b/src/main/resources/hudson/plugins/plot/PlotReport/index.jelly
@@ -68,7 +68,7 @@
   <l:layout title="${it.group}">
     <st:include it="${it.job}" page="sidepanel.jelly" optional="true" />
     <l:main-panel>
-      <h1><l:icon class="icon-graph icon-xlg"/>${it.group}</h1>
+      <h1 class="page-headline"><l:icon class="symbol-analytics icon-xlg"/> ${it.group}</h1>
       <div>
         <st:adjunct includes="hudson.plugins.plot.PlotReport.jump-to-plot" />
         ${%Jump to} <select class="plot-selector" name="choice">


### PR DESCRIPTION
## Replace outdated icons with analytics symbol

The [design library](https://weekly.ci.jenkins.io/design-library/symbols/) shows the preferred images for Jenkins icons.  The symbols scale better and look more consistent with the rest of Jenkins.

No tests added because this a a look and feel change.  Not well suited to automated tests.

### What has been done

1. I chose "analytics" from the available symbols listed in [Jenkins core](https://github.com/jenkinsci/jenkins/tree/master/war/src/main/resources/images/symbols).
2. I added the page-headline class to the h1 headings because that seems to be a class that is used in other page headlines.

<!-- optional. Should be removed if not applicable -->
### Screenshots

Before | After
:-: | :-:
![before](https://github.com/user-attachments/assets/db16c7d2-ea4b-45cc-98e6-8fc257cb26e0) | ![after](https://github.com/user-attachments/assets/8527475c-c0d8-4ce0-91ea-145b6f9d5de5) |



### How to test

* Confirmed that images were displayed as expected in freestyle projects and in matrix projects

### Checklist

- [x] Git commits follow [best practices](https://chris.beams.io/posts/git-commit/) <!-- mandatory -->
- [x] Build passes in Jenkins <!-- mandatory -->
- [x] Appropriate tests or explanation to why this change has no tests <!-- mandatory -->
- [x] Pull Request is marked with appropriate label (see `.github/release-drafter.yml`) <!-- mandatory -->
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

