### PR TITLE
[JENKINS-75090] Fix horizontal radio button overlap with later element

### DIFF
--- a/src/main/resources/hudson/plugins/plot/AbstractPlotPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/plot/AbstractPlotPublisher/config.jelly
@@ -109,6 +109,7 @@
                       </tr>
                     </table>
                   </div>
+                  <br/> <!-- insert line break to adapt to 2.479.x layout change -->
                   <f:entry title="${%CSV Exclusion values}" help="/plugin/plot/help-csv-exclusions.html">
                     <f:textbox name="exclusionValues" value="${series.exclusionValues}" />
                   </f:entry>

--- a/src/main/resources/hudson/plugins/plot/CSVSeries/config.jelly
+++ b/src/main/resources/hudson/plugins/plot/CSVSeries/config.jelly
@@ -44,6 +44,7 @@
                         </tr>
                     </table>
                 </div>
+                <br/> <!-- insert line break to adapt to 2.479.x layout change -->
                 <f:entry title="${%CSV Exclusion values}" help="/plugin/plot/help-csv-exclusions.html">
                     <f:textbox name="exclusionValues" value="${series.exclusionValues}"/>
                 </f:entry>


### PR DESCRIPTION
## [JENKINS-75090] Fix horizontal radio button overlap with later element

[JENKINS-75090](https://issues.jenkins.io/browse/JENKINS-75090) notes that Jenkins 2.479.x shows a different layout of the horizontal radio buttons that are created by this plugin.  Horizontal radio buttons are not in the Jenkins design library.  The horizontal radio buttons should be replaced in this plugin with standard components from the Jenkins design library.  However, that is a larger effort and will need more time.  This small change fixes the visual issue without replacing the entire configuration page.

Insert extra space between the overlapping elements to prevent overlap.  Not an elegant fix, but no worse than the current implementation and much faster than replacing the entire configuration page with a new implementation.

### Testing done

* Confirmed user interface does not overlap in 2.479.2 and 2.462.3
* Confirmed that the additional space is not too ugly on 2.462.3

## Screenshots

Jenkins 2.462.3 with the change:

![2-462-3-with-added-break](https://github.com/user-attachments/assets/1e5dc8a3-8049-4f3d-b79a-b0b0aa657cc5)


Jenkins 2.479.2 with the change:

![2-479-2-with-added-break](https://github.com/user-attachments/assets/e8fd098f-dd77-43e1-ba7b-53794c0e8a7e)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
