### PR TITLE
Remove badges from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 # Plot plugin
 
-[![codecov](https://codecov.io/gh/jenkinsci/plot-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/jenkinsci/plot-plugin)
-[![Jenkins Plugins](https://img.shields.io/jenkins/plugin/v/plot)](https://plugins.jenkins.io/plot)
-[![GitHub Release](https://img.shields.io/badge/dynamic/json?color=blue&label=changelog&query=$.tag_name&url=https://api.github.com/repos/jenkinsci/plot-plugin/releases/latest)](https://github.com/jenkinsci/plot-plugin/releases/latest)
-[![Jenkins Plugin installs](https://img.shields.io/jenkins/plugin/i/plot?color=blue)](https://plugins.jenkins.io/plot/)
-
-## Description
-
 This plugin provides generic plotting (or graphing) capabilities in Jenkins.
 
 This plugin will **plot** one or more **single values variations across builds** in one or more plots.


### PR DESCRIPTION
## Remove badges from documentation

The badges are given a prominent position at the top of the [user documentation](https://plugins.jenkins.io/plot/) but are of very little value to the user.  Those who want to know the current release can see it very clearly on the [plugins site](https://plugins.jenkins.io/plot/releases/) and on the [GitHub page](https://github.com/jenkinsci/plot-plugin/releases).

The coverage information from the codecov badge is available from the [coverage report](https://ci.jenkins.io/job/Plugins/job/plot-plugin/job/master/lastBuild/coverage/) on ci.jenkins.io and from the coverage check report on GitHub.  One more location for coverage reporting is not valuable enough to occupy the top line of the user documentation.

The installation count is provided on the plugins.jenkins.io page and includes a 12 month history graph and easy access to [detailed deployment statistics](https://old.stats.jenkins.io/pluginversions/plot.html) by plugin version and Jenkins core version.

### Testing done

Confirmed that the page renders correctly on GitHub.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
