### PR TITLE
[JENKINS-75091] Fix null pointer exception when title is missing

### DIFF
--- a/src/main/java/hudson/plugins/plot/Plot.java
+++ b/src/main/java/hudson/plugins/plot/Plot.java
@@ -425,6 +425,12 @@ public class Plot implements Comparable<Plot> {
     }
 
     public int compareTo(Plot o) {
+        if (title == null) {
+            return o == null || o.getTitle() == null ? 0 : -1;
+        }
+        if (o == null || o.getTitle() == null) {
+            return 1;
+        }
         return title.compareTo(o.getTitle());
     }
 


### PR DESCRIPTION
## [JENKINS-75091] Fix null pointer exception when title is missing

[JENKINS-75091](https://issues.jenkins.io/browse/JENKINS-75091) provides a sample Pipeline that throws a null pointer exception when viewing plots after a few executions of the job.

```
pipeline {
    agent {
        label 'linux'
    }
    stages {
        stage('Hello') {
            steps {
                echo 'Hello World'
                sh '''#!/bin/bash
[ ! -f plot-a.csv ] && echo "Line-A,Line-B" > plot-a.csv
let "OTHER_VAR=2*BUILD_ID+1"
echo $BUILD_ID,$OTHER_VAR >> plot-a.csv
                '''
                plot csvFileName: 'plot-923ffed9-0b83-4a7d-93eb-55894c27e904.csv',
                     csvSeries: [[file: 'plot-a.csv']],
                     group: 'Z-group',
                     style: 'line'
                plot csvFileName: 'plot-923ffed9-0b83-4a7d-93eb-111111111111.csv',
                     csvSeries: [[file: 'plot-a.csv']],
		     group: 'Z-group',
		     style: 'line'
            }
        }
    }
}
```

### Testing done

Created a Pipeline with that script before the change and confirmed that it reports a null pointer exception.  Used the same Pipeline after the fix and confirmed that the plugin is drawn correctly.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
